### PR TITLE
Convert step files to Raspberry Flavoured Markdown

### DIFF
--- a/en/step_1.md
+++ b/en/step_1.md
@@ -1,53 +1,33 @@
-<h2 class="c-project-heading--task">Print Hello</h2>
+## Print Hello
 
-➡️ Display the word 'Hello' on the screen
+➡️ Display the word 'Hello' on the screen.
 
 In Python, `print()` outputs strings (words or numbers) to the screen.
 
 Type the code to `print()` Hello to the screen:
 
-<div class="c-project-code">
-
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 10
-line_highlights: 11
----
+```python line_numbers="true" line_number_start="10" line_highlights="11"
 
 # Put code to run under here.
 print(f'Hello')
 
---- /code ---
-
-</div>
+```
 
 ## Now run your code
 
 This is what you should see when you run your code.
 
-<div class="c-project-output">
 ```
 Hello
 ```
-</div>
 
-### Tip
+> [!TIP]
+>
+> When you type an opening bracket `(` the code editor will automatically add a closing bracket `)`.
+> This also happens when you type an opening apostrophe `'`.
 
-<div class="c-project-callout c-project-callout--tip">
-
-When you type an opening bracket `(` the code editor will automatically add a closing bracket `)` 
-This also happens when you type an opening apostrophe `'`.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-If you get an error then check your code really carefully. Check there are single quotes around `Hello` so Python knows it is meant to be text.
-
-</div>
+> [!DEBUG]
+>
+> If you get an error then check your code really carefully. Check there are single quotes around `Hello` so Python knows it is meant to be text.
 
 Click the **Run** button and check that `Hello` appears in the output.

--- a/en/step_10.md
+++ b/en/step_10.md
@@ -1,16 +1,10 @@
-<h2 class="c-project-heading--task">Roll dice</h2>
+## Roll dice
 
 ➡️ Create a function to simulate rolling a dice.
 
-Create a function called `roll_dice()`, that prints out the number 4. 
+Create a function called `roll_dice()` that prints out the number 4. 
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 9
-line_highlights: 10, 11
----
+```python line_numbers="true" line_number_start="9" line_highlights="10,11"
 
 # Function definitions        
 def roll_dice():
@@ -18,27 +12,20 @@ def roll_dice():
     
 # Put code to run under here
 
---- /code ---
+```
 
 Then, call the function at the bottom of your code.
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 18
-line_highlights: 19
----
+```python line_numbers="true" line_number_start="18" line_highlights="19"
 print(f'The date and time is {datetime.now()}')
 roll_dice()
 
---- /code ---
+```
 
 ## Now run your code
 
 This is what you should see when you run your code.
 
-<div class="c-project-output">
 ```
 Hello 🌍🌎🌏
 Welcome to Python 🐍
@@ -47,22 +34,13 @@ Python 🐍 is good at maths!
 The date and time is 2023-11-21 15:55:33.038000
 You rolled a 4
 ```
-</div>
 
-### Tip
+> [!TIP]
+>
+> You can use the **Tab** key on your keyboard to insert 4 spaces. Pressing **Shift** and **Tab** will remove the 4 spaces.
 
-<div class="c-project-callout c-project-callout--tip">
-
-You can use the **Tab** key on your keyboard to insert 4 spaces. Pressing **Shift** and **Tab** will remove the 4 spaces.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-Check that you have brackets `()` and a colon `:` at the end of your function definition. Also check you are using brackets `()` when you call your function.
-
-</div>
+> [!DEBUG]
+>
+> Check that you have brackets `()` and a colon `:` at the end of your function definition. Also check you are using brackets `()` when you call your function.
 
 Click the **Run** button and check that the last line says `You rolled a 4`.

--- a/en/step_11.md
+++ b/en/step_11.md
@@ -1,22 +1,16 @@
-<h2 class="c-project-heading--task">Import randint</h2>
+## Import randint
 
 ➡️ Import the `randint` function from the `random` module.
 
-Another module called `random` can be used to create random numbers
+Another module called `random` can be used to create random numbers.
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 1
-line_highlights: 3
----
+```python line_numbers="true" line_number_start="1" line_highlights="3"
 
 # imports
 from datetime import datetime
 from random import randint
 
---- /code ---
+```
 
 Your code output will not change when you run it.
 

--- a/en/step_12.md
+++ b/en/step_12.md
@@ -1,28 +1,21 @@
-<h2 class="c-project-heading--task">Random numbers</h2>
+## Random numbers
 
 ➡️ Choose a random number for the dice roll.
 
 Use the `randint` function you imported to choose a random number between 1 and 6 for the dice roll.
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 10
-line_highlights: 12
----
+```python line_numbers="true" line_number_start="10" line_highlights="12"
 
 # Function definitions 
 def roll_dice():
     print(f'You rolled a {randint(1, 6)}')
     
---- /code ---
+```
 
 ## Now run your code
 
 Now when you run your code, a new random number between 1 and 6 will be chosen each time.
 
-<div class="c-project-output">
 ```
 Hello 🌍🌎🌏
 Welcome to Python 🐍
@@ -31,23 +24,13 @@ Python 🐍 is good at maths!
 The date and time is 2023-11-21 16:02:12.535000
 You rolled a 6
 ```
-</div>
 
-### Tip
+> [!TIP]
+>
+> `randint` is short for random integer. Integers are whole numbers.
 
-<div class="c-project-callout c-project-callout--tip">
-
-`randint` is short for random integer. Integers are whole numbers.
-
-</div>
-
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-Check your brackets and curly brackets if you get and error. Take note that the same number might be chosen over and over again. It's random!
-
-</div>
+> [!DEBUG]
+>
+> Check your brackets and curly brackets if you get an error. Take note that the same number might be chosen over and over again. It's random!
 
 Click the **Run** button and check that the last line says `You rolled a` followed by a number from 1 to 6.

--- a/en/step_13.md
+++ b/en/step_13.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Multiply strings</h2>
+## Multiply strings
 
 ➡️ Multiply the number by the 🔥 emoji to print the emoji a number of times equal to the dice roll.
 
@@ -6,42 +6,29 @@ In Python you can multiply strings such as emojis or whole words by a number, so
 
 Store the random number in a variable called `roll`.
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 10
-line_highlights: 12
----
+```python line_numbers="true" line_number_start="10" line_highlights="12"
 
 # Function definitions        
 def roll_dice():
     roll = randint(1,6)
 
---- /code ---
+```
 
 Multiply the random number stored in `roll` by the 🔥 emoji, and print the result.
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 10
-line_highlights: 13
----
+```python line_numbers="true" line_number_start="10" line_highlights="13"
 
 # Function definitions        
 def roll_dice():
     roll = randint(1,6)
     print(f'You rolled a {roll} {fire * roll}')
     
---- /code ---
+```
 
 ## Now run your code
 
 Your output code should look something like this:
 
-<div class="c-project-output">
 ```
 Hello 🌍🌎🌏
 Welcome to Python 🐍
@@ -50,14 +37,9 @@ Python 🐍 is good at maths!
 The date and time is 2023-11-21 16:14:45.140000
 You rolled a 4 🔥🔥🔥🔥
 ```
-</div>
 
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-Check all your brackets are the same as the code example above.
-
-</div>
+> [!DEBUG]
+>
+> Check all your brackets are the same as the code example above.
 
 Click the **Run** button and check that the last line shows the dice number and the same number of fire emojis.

--- a/en/step_14.md
+++ b/en/step_14.md
@@ -1,16 +1,10 @@
-<h2 class="c-project-heading--task">Get input</h2>
+## Get input
 
 ➡️ Allow the person using your program to type in some input.
 
 You can use `input()` to ask the person using your program to enter text, and save it as a variable.
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 10
-line_highlights: 12-13
----
+```python line_numbers="true" line_number_start="10" line_highlights="12-13"
 
 # Function definitions
 def roll_dice():
@@ -19,14 +13,13 @@ def roll_dice():
     roll = randint(1,6)
     print(f'You rolled a {roll} {fire * roll}')
 
---- /code ---
+```
 
 ## Now run your code
 
 Ensure you press the <kbd> Enter </kbd> key after inputting how many sides.
 This is what you should see when you run your code.
 
-<div class="c-project-output">
 ```
 Hello 🌍🌎🌏
 Welcome to Python 🐍
@@ -38,6 +31,5 @@ How many sides on your dice?:
 That is a D 20
 You rolled a 1 🔥
 ```
-</div>
 
 Click the **Run** button, type a number such as `20`, and check that the program says `That is a D 20` before showing a dice roll.

--- a/en/step_15.md
+++ b/en/step_15.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Change the dice</h2>
+## Change the dice
 
 ➡️ Generate a random number between 1 and the number of sides the user typed in.
 
@@ -6,13 +6,7 @@ Inputs are always stored as text, but we need to use the input stored in `max` t
 
 `max` is a string, so it needs changing to an integer `int()`.
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 10
-line_highlights: 14
----
+```python line_numbers="true" line_number_start="10" line_highlights="14"
 
 # Function definitions        
 def roll_dice():
@@ -21,13 +15,12 @@ def roll_dice():
     roll = randint(1, int(max))
     print(f'You rolled a {roll} {fire * roll}')
     
---- /code ---
+```
 
 ## Now run your code
 
 This is what you should see:
 
-<div class="c-project-output">
 ```
 Hello 🌍🌎🌏
 Welcome to Python 🐍
@@ -38,14 +31,9 @@ How many sides on your dice?:12
 That is a D 12
 You rolled a 5 🔥🔥🔥🔥🔥
 ```
-</div>
 
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-Changing one type of data to another type of data is called **type casting**.
-
-</div>
+> [!TIP]
+>
+> Changing one type of data to another type of data is called **type casting**.
 
 Click the **Run** button, type a number of sides, and check that the dice roll can be any number from 1 up to the number you entered.

--- a/en/step_16.md
+++ b/en/step_16.md
@@ -1,36 +1,27 @@
-<h2 class="c-project-heading--task">Over to you</h2>
+## Over to you
 
 ➡️ Practice adding more `print` lines to your code.
 
 Here are some sentence starters that you can use:
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 23
-line_highlights: 24-26
----
+```python line_numbers="true" line_number_start="23" line_highlights="24-26"
 
 roll_dice()
 print(f'I ❤️ ...')   
 print(f'... makes me 😃')   
 print(f'I would like to make ... with {python}')
 
---- /code ---
+```
 
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-Here is a list of some emojis you might like to use:
-
-🎊 🙌 🙌🏼 🙌🏽 🙌🏾 🙌🏿 😃 🕒 🎨 🎮 🔬 🎉 🕶️ 🎲 😊
-🦄 🚀 💯 ⭐ 💛 ❤️ 📚 ⚽ 🏏 🏀 🥋 🏆 ✨ 🥺 🌈 🔥 ♻️ 🌳
-👩‍🦽👩🏼‍🦽👩🏽‍🦽👩🏾‍🦽👩🏿‍🦽🧘 🧘🏼 🧘🏽 🧘🏾 🧘🏿 🙋 🙋🏼 🙋🏽 🙋🏾 🙋🏿
-
-You can copy and paste them into your code.
-</div>
+> [!TIP]
+>
+> Here is a list of some emojis you might like to use:
+>
+> 🎊 🙌 🙌🏼 🙌🏽 🙌🏾 🙌🏿 😃 🕒 🎨 🎮 🔬 🎉 🕶️ 🎲 😊
+> 🦄 🚀 💯 ⭐ 💛 ❤️ 📚 ⚽ 🏏 🏀 🥋 🏆 ✨ 🥺 🌈 🔥 ♻️ 🌳
+> 👩‍🦽👩🏼‍🦽👩🏽‍🦽👩🏾‍🦽👩🏿‍🦽🧘 🧘🏼 🧘🏽 🧘🏾 🧘🏿 🙋 🙋🏼 🙋🏽 🙋🏾 🙋🏿
+>
+> You can copy and paste them into your code.
 
 ## Now run your code
 

--- a/en/step_2.md
+++ b/en/step_2.md
@@ -1,24 +1,12 @@
-<h2 class="c-project-heading--task">Variables</h2>
+## Variables
 
 We have included some variables that store emoji characters.
 
-### Tip
+> [!TIP]
+>
+> A **variable** is used to store values such as text or numbers. Choosing a sensible name for a variable makes it easier for you to remember what it is for.
 
-<div class="c-project-callout c-project-callout--tip">
-
-A **variable** is used to store values such as text or numbers. Choosing a sensible name for a variable makes it easier for you to remember what it is for.
-
-</div>
-
-<div class="c-project-code">
-
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 3
-line_highlights: 4-6
----
+```python line_numbers="true" line_number_start="3" line_highlights="4-6"
 
 # variables
 world = '🌍🌎🌏'
@@ -30,9 +18,7 @@ fire = '🔥'
 # Put code to run under here
 print(f'Hello')
 
---- /code ---
-
-</div>
+```
 
 ## Now run your code
 

--- a/en/step_3.md
+++ b/en/step_3.md
@@ -1,16 +1,10 @@
-<h2 class="c-project-heading--task">Print variables</h2>
+## Print variables
 
 ➡️ Print the contents of a variable.
 
-Change your code to also `print()` the contents of the `world` variable. You can do this by adding the variable name in curly brackets `{}`
+Change your code to also `print()` the contents of the `world` variable. You can do this by adding the variable name in curly brackets `{}`.
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 3
-line_highlights: 11
----
+```python line_numbers="true" line_number_start="3" line_highlights="11"
 
 # variables
 world = '🌍🌎🌏'
@@ -22,33 +16,22 @@ fire = '🔥'
 # Put code to run under here
 print(f'Hello {world}')
 
---- /code ---
+```
 
 ## Now run your code
 
 This is what you should see when you run your code.
 
-<div class="c-project-output">
 ```
 Hello 🌍🌎🌏
 ```
-</div>
 
-### Tip
+> [!TIP]
+>
+> The `f` character inside the print lets you easily print variables along with strings of text.
 
-<div class="c-project-callout c-project-callout--tip">
-
-The `f` character inside the print lets you easily print variables along with strings of text.
-
-</div>
-
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-If you get an error then check you have opened and closed all your brackets `()` and curly brackets `{}`
-
-</div>
+> [!DEBUG]
+>
+> If you get an error then check you have opened and closed all your brackets `()` and curly brackets `{}`.
 
 Click the **Run** button and check that `Hello` is followed by the globe emojis.

--- a/en/step_4.md
+++ b/en/step_4.md
@@ -1,30 +1,22 @@
-<h2 class="c-project-heading--task">Print another variable</h2>
+## Print another variable
 
 **Add** another line to your code to `print()` more text and emojis:
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 10
-line_highlights: 12
----
+```python line_numbers="true" line_number_start="10" line_highlights="12"
 
 # Put code to run under here
 print(f'Hello {world}')
 print(f'Welcome to {python}')
 
---- /code ---
+```
 
 ## Now run your code
 
 This is what you should see when you run your code.
 
-<div class="c-project-output">
 ```
 Hello 🌍🌎🌏
 Welcome to Python 🐍
 ```
-</div>
 
 Click the **Run** button and check that the output has two lines: `Hello` with the globe emojis and `Welcome to Python 🐍`.

--- a/en/step_5.md
+++ b/en/step_5.md
@@ -1,8 +1,8 @@
-<h2 class="c-project-heading--task">Operators</h2>
+## Operators
 
 In Python you can work with numbers and dates.
 
-You can use **arithmetic operators** such as `+` and `-`  to do calculations:
+You can use **arithmetic operators** such as `+` and `-` to do calculations:
 
 | + | add |   
 | - | subtract |   

--- a/en/step_6.md
+++ b/en/step_6.md
@@ -1,16 +1,10 @@
-<h2 class="c-project-heading--task">Create a calculation</h2>
+## Create a calculation
 
 ➡️ Print the value of a calculation.
 
 Add two more `print()` lines to your code including a multiplication for Python to calculate:
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 10
-line_highlights: 13-14
----
+```python line_numbers="true" line_number_start="10" line_highlights="13-14"
 
 # Put code to run under here
 print(f'Hello {world}')
@@ -18,37 +12,25 @@ print(f'Welcome to {python}')
 print(f'{python} is good at maths!')
 print(f'{111111111 * 111111111}')
 
---- /code ---
+```
 
 ## Now run your code
 
 This is what you should see when you run your code.
 
-<div class="c-project-output">
 ```
 Hello 🌍🌎🌏
 Welcome to Python 🐍
 Python 🐍 is good at maths!
 12345678987654321
 ```
-</div>
 
+> [!TIP]
+>
+> Python uses the same rules for calculations as you might have learned at school. **B**rackets first, then **O**rders, **D**ivision, **M**ultiplication, **A**ddition, and lastly **S**ubtraction.
 
-### Tip
-
-<div class="c-project-callout c-project-callout--tip">
-
-Python uses the same rules for calculations as you might have learned at school. **B**rackets first, then **O**rders, **D**ivision, **M**ultiplication, **A**ddition, and lastly **S**ubtraction.
-
-</div>
-
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-Don't forget that the UPPERCASE and lowercase letters are important in Python. Always check you are using the correct case.
-
-</div>
+> [!DEBUG]
+>
+> Don't forget that the UPPERCASE and lowercase letters are important in Python. Always check you are using the correct case.
 
 Click the **Run** button and check that your program now prints a maths message and a large number on the next line.

--- a/en/step_7.md
+++ b/en/step_7.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Using modules</h2>
+## Using modules
 
 ➡️ Import the `datetime` module.
 
@@ -6,38 +6,24 @@ Python has many **modules** that you can use in your code to help perform certai
 
 The `datetime` module helps with writing code that uses dates and times.
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 1
-line_highlights: 2
----
+```python line_numbers="true" line_number_start="1" line_highlights="2"
 
 # imports
 from datetime import datetime
 
 # variables
 
---- /code ---
+```
 
 When you run this code, nothing should change, and you should have the same output as the previous step.
 
-### Tip
+> [!TIP]
+>
+> Any text you write in Python with a `#` in front of it becomes a comment. These lines won't run, so they can be useful to help people read and understand your code.
 
-<div class="c-project-callout c-project-callout--tip">
-
-Any text you write in Python with a `#` in front of it becomes a comment. These lines won't run, so they can be useful to help people read and understand your code.
-
-</div>
-
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-Check that you have spelled `datetime` correctly, and it is all lowercase.
-
-</div>
+> [!DEBUG]
+>
+> Check that you have spelled `datetime` correctly, and it is all lowercase.
 
 ## Now run your code
 

--- a/en/step_8.md
+++ b/en/step_8.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Print the date</h2>
+## Print the date
 
 ➡️ Display the current date and time.
 
@@ -6,25 +6,18 @@ Add another line to your code to `print` the current date and time.
 
 Get the current date and time by using the `now()` function from the `datetime` module:
 
---- code ---
----
-language: python
-line_numbers: true
-line_number_start: 14
-line_highlights: 16
----
+```python line_numbers="true" line_number_start="14" line_highlights="16"
 
 print(f'{python} is good at maths!')
 print(f'{111111111 * 111111111}')
 print(f'The date and time is {datetime.now()}')
 
---- /code ---
+```
 
 ## Now run your code
 
 This is what you should see when you run your code, but the date and time will be different.
 
-<div class="c-project-output">
 ```
 Hello 🌍🌎🌏
 Welcome to Python 🐍
@@ -32,14 +25,9 @@ Python 🐍 is good at maths!
 12345678987654321
 The date and time is 2023-11-21 15:34:10.148000
 ```
-</div>
 
-### Debugging
-
-<div class="c-project-callout c-project-callout--debug">
-
-Check all your brackets `()` and curly brackets `{}` to make sure they are all opened and closed in the correct place.
-
-</div>
+> [!DEBUG]
+>
+> Check all your brackets `()` and curly brackets `{}` to make sure they are all opened and closed in the correct place.
 
 Click the **Run** button and check that the output now includes a line that starts with `The date and time is`, followed by the current date and time.

--- a/en/step_9.md
+++ b/en/step_9.md
@@ -1,4 +1,4 @@
-<h2 class="c-project-heading--task">Functions</h2>
+## Functions
 
 Functions are blocks of code that perform specific tasks.
 
@@ -6,20 +6,14 @@ They can be used over and over again.
 
 Here is an example of a function:
 
-<div class="c-project-code">
---- code ---
----
-language: python
-line_numbers: false
----
+```python
 
 # Function definitions
 def add_one_and_one():
     x = 1 + 1
     print(x)
 
---- /code ---
-</div>
+```
 
 The name of this function is `add_one_and_one`. 
 


### PR DESCRIPTION
Converts all step files to the Raspberry Flavoured Markdown spec. (Published project — `listed: true` unchanged.)

**Conversion**
- Task headings → `##`; single-task steps no sub-heading; step_5 "Operators" kept as a normal step
- Code → fenced blocks with inline attributes (code byte-preserved)
- Tip/debug callouts → `> [!TIP]` / `> [!DEBUG]`; output wrappers dropped → bare text fences after "Now run your code"

**SPAG (all pointed out):** missing full stops (steps 1, 3, 11 + tips/debugs); double space (step_5); stray comma (step_10); "and error" → "an error" (step_12 debug).

No content/code errors found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)